### PR TITLE
Adding sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: elixir
 notifications:
   recipients:


### PR DESCRIPTION
Adding `sudo: false` so that tests use containers which are faster
